### PR TITLE
chore: simplify Prisma commands in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ COPY . .
 RUN ls -la prisma
 
 # # Jalankan perintah Prisma
-RUN npm run db:pull && npm run db:generate
+RUN npm run db:generate
 
 # Build aplikasi
 RUN npm run build


### PR DESCRIPTION
- Removed the db:pull command from the Dockerfile to streamline the Prisma setup process.
- Retained the db:generate command for generating Prisma client.