### PR TITLE
refactor: reuse Prisma module for shared database client

### DIFF
--- a/src/modules/charges/charges.module.ts
+++ b/src/modules/charges/charges.module.ts
@@ -1,12 +1,13 @@
 import { Module } from '@nestjs/common';
 import { ChargesService } from './services/charges.service';
 import { ChargesController } from './controllers/charges.controller';
-import { PrismaService } from 'src/prisma/prisma.service';
+import { PrismaModule } from 'src/prisma/prisma.module';
 import { Reflector } from '@nestjs/core';
 
 @Module({
-  providers: [ChargesService, PrismaService, Reflector],
+  imports: [PrismaModule],
+  providers: [ChargesService, Reflector],
   controllers: [ChargesController],
-  exports: [ChargesService, PrismaService],
+  exports: [ChargesService],
 })
 export class ChargesModule {}

--- a/src/modules/dashboard/dashboard.module.ts
+++ b/src/modules/dashboard/dashboard.module.ts
@@ -1,10 +1,11 @@
 import { Module } from '@nestjs/common';
-import { PrismaService } from 'src/prisma/prisma.service';
+import { PrismaModule } from 'src/prisma/prisma.module';
 import { DashboardController } from './dashboard.controller';
 import { DashboardService } from './dashboard.service';
 
 @Module({
+  imports: [PrismaModule],
   controllers: [DashboardController],
-  providers: [DashboardService, PrismaService],
+  providers: [DashboardService],
 })
 export class DashboardModule {}

--- a/src/modules/facilities/facilities.module.ts
+++ b/src/modules/facilities/facilities.module.ts
@@ -1,11 +1,12 @@
 import { Module } from '@nestjs/common';
-import { PrismaService } from 'src/prisma/prisma.service';
+import { PrismaModule } from 'src/prisma/prisma.module';
 import { FacilitiesController } from './facilities.controller';
 import { FacilitiesService } from './facilities.service';
 import { Reflector } from '@nestjs/core';
 
 @Module({
+  imports: [PrismaModule],
   controllers: [FacilitiesController],
-  providers: [FacilitiesService, PrismaService, Reflector],
+  providers: [FacilitiesService, Reflector],
 })
 export class FacilitiesModule {}

--- a/src/modules/integrations/integrations.module.ts
+++ b/src/modules/integrations/integrations.module.ts
@@ -1,12 +1,12 @@
 import { Module } from '@nestjs/common';
-import { PrismaService } from 'src/prisma/prisma.service';
+import { PrismaModule } from 'src/prisma/prisma.module';
 import { StorageServiceModule } from '../storage-service/storage-service.module';
 import { IntegrationsController } from './integrations.controller';
 import { IntegrationsService } from './integrations.service';
 
 @Module({
-  imports: [StorageServiceModule],
+  imports: [PrismaModule, StorageServiceModule],
   controllers: [IntegrationsController],
-  providers: [IntegrationsService, PrismaService],
+  providers: [IntegrationsService],
 })
 export class IntegrationsModule {}

--- a/src/modules/invoices/invoices.module.ts
+++ b/src/modules/invoices/invoices.module.ts
@@ -1,6 +1,6 @@
 import { forwardRef, Module } from '@nestjs/common';
 import { InvoiceService } from './services/invoices.service';
-import { PrismaService } from 'src/prisma/prisma.service';
+import { PrismaModule } from 'src/prisma/prisma.module';
 import { InvoiceController } from './controllers/invoices.controller';
 import { PaymentFactory } from './factories/payment.factory';
 import { MidtransProvider } from './providers/midtrans.provider';
@@ -22,6 +22,7 @@ import { Reflector } from '@nestjs/core';
 
 @Module({
   imports: [
+    PrismaModule,
     MailModule,
     StorageServiceModule,
     KitchenModule,
@@ -30,7 +31,6 @@ import { Reflector } from '@nestjs/core';
   providers: [
     InvoiceService,
     PaymentFactory,
-    PrismaService,
     MidtransProvider,
     NotificationHelper,
     PaymentLogsService,
@@ -46,7 +46,6 @@ import { Reflector } from '@nestjs/core';
   controllers: [InvoiceSettingController, InvoiceController],
   exports: [
     InvoiceService,
-    PrismaService,
     NotificationHelper,
     PaymentLogsService,
     ChargesService,

--- a/src/modules/kitchen/kitchen.module.ts
+++ b/src/modules/kitchen/kitchen.module.ts
@@ -1,12 +1,13 @@
 import { Module } from '@nestjs/common';
 import { KitchenController } from './controllers/kitchen.controller';
 import { KitchenService } from './services/kitchen.service';
-import { PrismaService } from 'src/prisma/prisma.service';
+import { PrismaModule } from 'src/prisma/prisma.module';
 import { Reflector } from '@nestjs/core';
 
 @Module({
+  imports: [PrismaModule],
   controllers: [KitchenController],
-  providers: [KitchenService, PrismaService, Reflector],
-  exports: [KitchenService, PrismaService],
+  providers: [KitchenService, Reflector],
+  exports: [KitchenService],
 })
 export class KitchenModule {}

--- a/src/modules/payment-logs/payment-logs.module.ts
+++ b/src/modules/payment-logs/payment-logs.module.ts
@@ -1,9 +1,10 @@
 import { Module } from '@nestjs/common';
 import { PaymentLogsService } from './services/payment-logs.service';
-import { PrismaService } from 'src/prisma/prisma.service';
+import { PrismaModule } from 'src/prisma/prisma.module';
 
 @Module({
-  providers: [PaymentLogsService, PrismaService],
+  imports: [PrismaModule],
+  providers: [PaymentLogsService],
   exports: [PaymentLogsService],
 })
 export class PaymentLogsModule {}

--- a/src/modules/payment-methods/payment-method.module.ts
+++ b/src/modules/payment-methods/payment-method.module.ts
@@ -1,14 +1,14 @@
 import { Module } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
-import { PrismaService } from 'src/prisma/prisma.service';
+import { PrismaModule } from 'src/prisma/prisma.module';
 import { StorageServiceModule } from '../storage-service/storage-service.module';
 import { PaymentMethodController } from './controllers/payment-method.controller';
 import { PaymentMethodService } from './services/payment-method.service';
 
 @Module({
-  imports: [StorageServiceModule],
-  providers: [PaymentMethodService, PrismaService, Reflector],
+  imports: [PrismaModule, StorageServiceModule],
+  providers: [PaymentMethodService, Reflector],
   controllers: [PaymentMethodController],
-  exports: [PaymentMethodService, PrismaService],
+  exports: [PaymentMethodService],
 })
 export class PaymentMethodModule {}

--- a/src/modules/payment-rounding-setting/payment-rounding-setting.module.ts
+++ b/src/modules/payment-rounding-setting/payment-rounding-setting.module.ts
@@ -1,11 +1,12 @@
 import { Module } from '@nestjs/common';
 import { PaymentRoundingSettingController } from './controllers/payment-rounding-setting.controller';
 import { PaymentRoundingSettingService } from './services/payment-rounding-setting.service';
-import { PrismaService } from 'src/prisma/prisma.service';
+import { PrismaModule } from 'src/prisma/prisma.module';
 
 @Module({
+  imports: [PrismaModule],
   controllers: [PaymentRoundingSettingController],
-  providers: [PaymentRoundingSettingService, PrismaService],
+  providers: [PaymentRoundingSettingService],
   exports: [PaymentRoundingSettingService],
 })
 export class PaymentRoundingSettingModule {}

--- a/src/modules/product-bundling/product-bundling.module.ts
+++ b/src/modules/product-bundling/product-bundling.module.ts
@@ -1,11 +1,12 @@
 import { Module } from '@nestjs/common';
-import { PrismaService } from 'src/prisma/prisma.service';
+import { PrismaModule } from 'src/prisma/prisma.module';
 import { ProductBundlingController } from './product-bundling.controller';
 import { ProductBundlingService } from './product-bundling.service';
 import { Reflector } from '@nestjs/core';
 
 @Module({
+  imports: [PrismaModule],
   controllers: [ProductBundlingController],
-  providers: [ProductBundlingService, PrismaService, Reflector],
+  providers: [ProductBundlingService, Reflector],
 })
 export class ProductBundlingModule {}

--- a/src/modules/report/report.module.ts
+++ b/src/modules/report/report.module.ts
@@ -1,10 +1,11 @@
 import { Module } from '@nestjs/common';
-import { PrismaService } from 'src/prisma/prisma.service';
+import { PrismaModule } from 'src/prisma/prisma.module';
 import { ReportController } from './report.controller';
 import { ReportService } from './report.service';
 
 @Module({
+  imports: [PrismaModule],
   controllers: [ReportController],
-  providers: [ReportService, PrismaService],
+  providers: [ReportService],
 })
 export class ReportModule {}

--- a/src/modules/tables/tables.module.ts
+++ b/src/modules/tables/tables.module.ts
@@ -1,7 +1,6 @@
 import { Module } from '@nestjs/common';
 import { TablesService } from './tables.service';
 import { TablesController } from './tables.controller';
-import { PrismaService } from '../../prisma/prisma.service';
 import { PrismaModule } from '../../prisma/prisma.module';
 import { StorageServiceModule } from '../storage-service/storage-service.module';
 

--- a/src/modules/tag/tag.module.ts
+++ b/src/modules/tag/tag.module.ts
@@ -1,7 +1,6 @@
 import { Module } from '@nestjs/common';
 import { TagService } from './tag.service';
 import { TagController } from './tag.controller';
-import { PrismaService } from '../../prisma/prisma.service';
 import { PrismaModule } from '../../prisma/prisma.module';
 
 @Module({


### PR DESCRIPTION
## Summary
- update feature modules to import PrismaModule instead of re-declaring PrismaService
- stop exporting PrismaService from feature modules so all consumers share the Prisma singleton

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68dcb61454bc832385bea2aad53d6f67